### PR TITLE
Implement module_author ckeditor layout

### DIFF
--- a/app/controllers/udl_module_sections_controller.rb
+++ b/app/controllers/udl_module_sections_controller.rb
@@ -1,6 +1,7 @@
 class UdlModuleSectionsController < ApplicationController
   before_action :set_section, only: [ :edit, :update, :destroy]
   before_action :set_module, only: [ :index, :create, :edit, :update ]
+  before_action :current_user
   load_and_authorize_resource
 
   def index

--- a/app/helpers/udl_module_helper.rb
+++ b/app/helpers/udl_module_helper.rb
@@ -11,4 +11,11 @@ module UdlModuleHelper
    class_name = 'udl-none' if !udl_module.udl_representation && !udl_module.udl_action_expression && !udl_module.udl_engagement
    class_name
   end
+
+  def module_admin?(user)
+    user.roles.each do |role|
+      return true if ['admin','modules_admin'].include? role.name
+    end
+    false
+  end
 end

--- a/app/views/udl_module_sections/_edit_form.html.erb
+++ b/app/views/udl_module_sections/_edit_form.html.erb
@@ -4,7 +4,12 @@
     <%= f.check_box :hide_title %>
   </div>
   <div class="field">
-    <%= f.cktext_area :content, ckeditor: { toolbar: 'module_author', height: 600 } %>
+   <% if module_admin?(@current_user)%>
+     <%= f.cktext_area :content, ckeditor: { toolbar: 'module_admin', height: 600 } %>
+     <% else %>
+      
+     <%= f.cktext_area :content, ckeditor: { toolbar: 'module_author', height: 600 } %>
+     <% end %>
   </div>   
   <div class="actions">
     <p>


### PR DESCRIPTION
Implemented two views of ck editor, module_admin and module_author, to
remove unnecessary functionality from the author role.
