### PR TITLE
Add Helper spec for UdlModuleHelper

### DIFF
--- a/spec/helpers/udl_module_helper_spec.rb
+++ b/spec/helpers/udl_module_helper_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe UdlModuleHelper do
+  let(:admin) { create(:admin_user) }
+  let(:user) { create(:user) }
+  describe "#module_admin?" do
+    context "with admin user" do
+      it "should return true" do
+        expect( helper.module_admin?(admin) ).to be true
+      end
+    end
+    context "with normal user" do
+      it "should return false" do
+        expect( helper.module_admin?(user) ).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a helper spec for the UdlModuleHelper with tests around the
module_admin? method. This method takes a user as an argument and
determines whether or not a user has module_admin privileges.
