### PR TITLE
Add column height fix for sidebar

### DIFF
--- a/app/assets/javascripts/column_fix.js
+++ b/app/assets/javascripts/column_fix.js
@@ -1,0 +1,12 @@
+// On pages with a sidebar, the sidebar's height needs
+// to be equal to the height of the main content.
+
+$(window).load(function() {
+  col_fix();
+});
+
+function col_fix() {
+  var max_height = $("#right-column-wrapper").height();
+  var total_border_height = 2;
+  $("#left-column-wrapper").height(max_height - total_border_height + "px");
+}

--- a/spec/helpers/udl_module_helper_spec.rb
+++ b/spec/helpers/udl_module_helper_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe UdlModuleHelper do
+  let(:admin) { create(:admin_user) }
+  let(:user) { create(:user) }
+  describe "#module_admin?" do
+    context "with admin user" do
+      it "should return true" do
+        expect( helper.module_admin?(admin) ).to be true
+      end
+    end
+    context "with normal user" do
+      it "should return false" do
+        expect( helper.module_admin?(user) ).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
The side bar on the main marketing pages for collegestar.org needs to
get its height information from the height of the main content section.
app/assets/javascripts/column_fix.js does this.
