### PR TITLE
Add redirect routes for legacy.collegestar.org

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,38 @@ Rails.application.routes.draw do
   get 'login' => 'sessions#new', as: :login
   get 'logout' => 'sessions#destroy', as: :logout
 
+  # Legacy Udl Module redirects
+  # The original modules had a "coded" naming convention, this was a really bad idea for SEO.
+  # we need to 301 redirect these old module url's to the new naming scheme
+
+  # The following modules are not released on the new site and need to be redirected back to
+  # their original implementations:
+  [ 'clae', 'cq', 'crs', 'csi', 'gam', 'lsp', 'pse', 
+    'qrc', 'uosc', 'ibl', 'wle','wln', 'wra' ].each do |legacy_url|
+    get "/modules/#{legacy_url}", to: redirect("http://legacy.collegestar.org/modules/#{legacy_url}/introduction")
+    get "/modules/#{legacy_url}/:page", to: redirect("http://legacy.collegestar.org/modules/#{legacy_url}/%{page}")
+  end
+
+  # The following modules do have a new module name and need to be redirected within
+  # the rails app.
+
+  get '/modules/aopsl', to: redirect('/modules/advance-organizers')
+  get '/modules/aopsl/:page', to: redirect('/modules/advance-organizers#%{page}')
+  get '/modules/col', to: redirect('/modules/cooperative-learning')
+  get '/modules/col/:page', to: redirect('/modules/cooperative-learning#%{page}')
+  get '/modules/fc', to: redirect('/modules/flipped-classroom')
+  get '/modules/fc/:page', to: redirect('/modules/flipped-classroom#%{page}')
+  get '/modules/lc', to: redirect('/modules/lecture-capture')
+  get '/modules/lc/:page', to: redirect('/modules/lecture-capture#%{page}')
+  get '/modules/mdi', to: redirect('/modules/mnemonic-devices-for-instruction')
+  get '/modules/mdi/:page', to: redirect('/modules/mnemonic-devices-for-instruction#%{page}')
+  get '/modules/pw', to: redirect('/modules/pedagogy-wheel')
+  get '/modules/pw/:page', to: redirect('/modules/pedagogy-wheeli#%{page}')
+  get '/modules/rwg', to: redirect('/modules/read-write')
+  get '/modules/rwg/:page', to: redirect('/modules/read-write#%{page}')
+  get '/modules/usoc', to: redirect('/modules/using-syllabi-to-organize-courses')
+  get '/modules/usoc/:page', to: redirect('/modules/using-syllabi-to-organize-courses#%{page}')
+  
   resources :sessions, only: [:create, :destroy]
   resources :password_resets, except: [:index, :show], path: '/password-resets'
   resources :users, only: [:index, :new, :create, :update, :destroy]


### PR DESCRIPTION
The naming scheme for the udl modules changed from a code representing
the title of the modules to a slugged title. We still need to route
those old urls to the correct place. Some of the new modules are not
ready yet, so we will 301 redirect them to the legacy.collegestar.org
site until they are live on collegestar.org.
