### PR TITLE
Update NewsArticle Spec Uniqueness test

### DIFF
--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -2,7 +2,7 @@ class NewsArticle < ActiveRecord::Base
   validates :title, presence: true, uniqueness: true
   validates :slug, presence: true, uniqueness: true
   validates :content, presence: true
-  validates :feature_article, uniqueness: true, if: :feature_article
+  validates :feature_article, uniqueness: true, if: :feature_article?
 
   def self.order_by_created_date_and_limit(limit = 10)
     articles = limit(limit).order(created_at: :desc)

--- a/spec/models/news_article_spec.rb
+++ b/spec/models/news_article_spec.rb
@@ -2,8 +2,14 @@ RSpec.describe NewsArticle do
 
   describe "validations" do
     describe "feature_article" do
+      # I can't figure out how to get shoulda matchers to work with this test.
+      # Shoulda sets feature_article to an arbitrary variable to be read as false,
+      # this causes issues with ruby/rails.
       context "not feature_article" do
-        it { should_not validate_uniqueness_of(:feature_article) }
+        it "should not validate uniqueness" do
+          create(:news_article)
+          expect(build(:news_article)).to be_valid
+        end
       end
       context "is feature_aticle" do
         subject do


### PR DESCRIPTION
The way Shoulda matchers tests the uniqueness of a boolean column was
generating a depreciation warning in rails. I'm still not sure if there
is a way to test the functionality with shoulda matchers, but it was
trivial to write a working test and I'll go with that instead.
