### PR TITLE
Add basic institutional admin pages

### DIFF
--- a/app/controllers/institutional_colleges_controller.rb
+++ b/app/controllers/institutional_colleges_controller.rb
@@ -1,0 +1,21 @@
+class InstitutionalCollegesController < ApplicationController
+  before_action :set_campus 
+  before_action :set_college, only: [:show, :edit, :update, :destroy]
+
+  def index
+    @units = InstitutionalCollege.where( campus_id: @campus.id ).order( :name )
+  end
+
+  def show
+  end
+
+  private
+
+  def set_campus
+    @campus = Campus.find_by slug: params[:campus_slug]
+  end
+
+  def set_college
+    @college = InstitutionalCollege.find_by slug: params[:slug]
+  end
+end

--- a/app/controllers/institutional_departments_controller.rb
+++ b/app/controllers/institutional_departments_controller.rb
@@ -1,0 +1,22 @@
+class InstitutionalDepartmentsController < ApplicationController
+  before_action :set_campus
+  before_action :set_college
+  before_action :set_department, only: [:show, :edit, :update, :destroy]
+
+  def show
+  end
+
+  private
+
+  def set_campus
+    @campus = Campus.find_by slug: params[:campus_slug]
+  end
+
+  def set_college
+    @college = InstitutionalCollege.find_by slug: params[:college_slug]
+  end
+
+  def set_department
+    @department = InstitutionalDepartment.find_by slug: params[:slug]
+  end
+end

--- a/app/models/administrator_unit_association.rb
+++ b/app/models/administrator_unit_association.rb
@@ -1,4 +1,7 @@
 class AdministratorUnitAssociation < ActiveRecord::Base
   belongs_to :institutional_administrator
   belongs_to :institutional_unit
+  belongs_to :institutional_college, foreign_key: 'institutional_unit_id'
+  belongs_to :institutional_department, foreign_key: 'institutional_unit_id'
+
 end

--- a/app/models/institutional_administrator.rb
+++ b/app/models/institutional_administrator.rb
@@ -1,9 +1,24 @@
 class InstitutionalAdministrator < ActiveRecord::Base
   
+  after_commit :update_parents
+
   validates :first_name, :last_name, :admin_email, presence: true
   validates_uniqueness_of :admin_email
 
-  has_many :administrator_unit_associations 
-  has_many :units, through: :administrator_unit_associations, foreign_key: "insitutional_unit_id"
+  has_many :administrator_unit_associations, dependent: :destroy
+  has_many :colleges, through: :administrator_unit_associations, source: :institutional_college
+  has_many :departments, through: :administrator_unit_associations, source: :institutional_department
 
+  private
+
+  def update_parents
+    query = <<-SQL.gsub(/\s+/, " ").strip
+      UPDATE institutional_units
+      SET updated_at = '#{Time.now.getutc}'
+      FROM administrator_unit_associations
+      WHERE administrator_unit_associations.institutional_administrator_id = #{self.id}
+      AND administrator_unit_associations.institutional_unit_id = institutional_units.id
+    SQL
+    ActiveRecord::Base.connection.execute( query )
+  end
 end

--- a/app/models/institutional_college.rb
+++ b/app/models/institutional_college.rb
@@ -1,6 +1,11 @@
 class InstitutionalCollege < InstitutionalUnit
   
-  has_many :administrator_unit_associations, foreign_key: :institutional_unit_id
-  has_many :deans, through: :administrator_unit_associations, source: :institutional_administrator
-  has_many :departments, class_name: "InstitutionalDepartment", foreign_key: :institutional_unit_id
+  has_many :departments, class_name: "InstitutionalDepartment", foreign_key: :institutional_unit_id, dependent: :nullify
+  has_many :administrator_unit_associations, foreign_key: :institutional_unit_id, dependent: :destroy
+  has_many :deans, -> { distinct }, through: :administrator_unit_associations, source: :institutional_administrator
+  has_one :current_dean_unit_association, -> { where current_dean: true }, 
+                                             class_name: "AdministratorUnitAssociation",
+                                             foreign_key: :institutional_unit_id, 
+                                             dependent: :destroy
+  has_one :current_dean, through: :current_dean_unit_association, source: :institutional_administrator
 end

--- a/app/models/institutional_department.rb
+++ b/app/models/institutional_department.rb
@@ -1,8 +1,26 @@
 class InstitutionalDepartment < InstitutionalUnit
   
+  after_commit :update_parents, on: :update
+  
   belongs_to :institutional_unit
-  has_many :administrator_unit_associations, foreign_key: :institutional_unit_id
-  has_many :chairs, through: :administrator_unit_associations, source: :institutional_administrator
-  has_many :department_faculty_associations, foreign_key: :department_id
+  has_many :administrator_unit_associations, foreign_key: :institutional_unit_id, dependent: :destroy
+  has_many :chairs, -> { distinct }, through: :administrator_unit_associations, source: :institutional_administrator
+  has_one :current_chair_unit_association, -> { where current_chair: true }, 
+                                            class_name: 'AdministratorUnitAssociation', 
+                                            foreign_key: :institutional_unit_id, 
+                                            dependent: :destroy  
+  has_one :current_chair, through: :current_chair_unit_association, source: :institutional_administrator
+  has_many :department_faculty_associations, foreign_key: :department_id, dependent: :destroy
   has_many :faculty, through: :department_faculty_associations
+
+  private
+
+  def update_parents
+    query = <<-SQL.gsub(/\s+/, " ").strip
+      UPDATE institutional_units
+      SET updated_at='#{Time.now.getutc}'
+      WHERE id=#{self.institutional_unit_id}
+    SQL
+    ActiveRecord::Base.connection.execute( query )
+  end
 end

--- a/app/models/institutional_faculty.rb
+++ b/app/models/institutional_faculty.rb
@@ -3,6 +3,6 @@ class InstitutionalFaculty < ActiveRecord::Base
   validates_uniqueness_of :email
 
   belongs_to :campus
-  has_many :faculty_course_associations
+  has_many :faculty_course_associations, dependent: :destroy
   has_many :courses, through: :faculty_course_associations, source: :institutional_course
 end

--- a/app/views/institutional_colleges/index.html.erb
+++ b/app/views/institutional_colleges/index.html.erb
@@ -1,0 +1,23 @@
+<% content_for :title, "#{@campus.name.html_safe} Schools & Colleges"  %>
+
+<div id="content-wrapper">
+  <div id="single-column-wrapper">
+    <div id="content">
+      <h1><%= @campus.name.html_safe %> Schools &amp; Colleges</h1>
+      <div id="campus-units-table-wrapper">
+        <table id="campus-units">
+          <tr>
+            <th width="80%">College/School</th>
+            <th width="20%">Last updated</th>
+          </tr>
+          <% @units.each do |unit| %>
+            <tr>
+              <td><%= link_to unit.name, campus_institutional_college_path( campus_slug: @campus.slug, slug: unit.slug ) %></td>
+              <td><%= unit.updated_at.strftime("%b %d, %Y") %></td>
+            </tr>
+          <% end %>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/institutional_colleges/show.html.erb
+++ b/app/views/institutional_colleges/show.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, "#{@college.name.html_safe}" %>
+
+<div id="content-wrapper">
+  <div id="single-column-wrapper">
+    <div id="content">
+      <h1><%= @college.name.html_safe %></h1>
+      <h2>Dean</h2>
+      <p>
+        <%= "#{@college.current_dean.title.html_safe} #{@college.current_dean.first_name.html_safe} #{@college.current_dean.last_name.html_safe}" %>
+      </p>
+
+      <h2>Departments</h2>
+      <ul>
+      <% @college.departments.each do |department| %>
+        <li><%= link_to department.name, campus_institutional_college_institutional_department_path( 
+                  campus_slug: @campus.slug,
+                  institutional_college_slug: @college.slug,
+                  slug: department.slug
+                ) %>
+      <% end %>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/app/views/institutional_departments/show.html.erb
+++ b/app/views/institutional_departments/show.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, @department.name.html_safe %>
+
+<div id="content-wrapper">
+  <div id="single-column-wrapper">
+    <div id="content">
+      <h1><%= @department.name.html_safe %></h1>
+      <h2>Chair</h2>
+      <p>
+        <%= "#{@department.current_chair.title.html_safe} #{@department.current_chair.first_name.html_safe} #{@department.current_chair.last_name.html_safe}" %>
+      </p>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,7 +61,13 @@ Rails.application.routes.draw do
   resources :pages, param: :slug
   resources :news_articles, only: [:new], path: '/news-article'
   resources :news, except: :new, param: :slug, controller: :news_articles, as: :news_articles
-  resources :campuses, param: :slug
+  resources :campuses, param: :slug do
+    resources :institutional_colleges, param: :slug, path: '/colleges' do
+      resources :institutional_departments, param: :slug, path: '/departments'
+    end
+    resources :institutional_administrators, path: '/administrators'
+  end
+
   resources :events, param: :slug
   resources :modules, param: :slug, controller: :udl_modules, as: :udl_modules do
     resources :sections, except: [:show, :index], param: :slug, controller: :udl_module_sections, as: :sections
@@ -79,11 +85,12 @@ Rails.application.routes.draw do
   namespace :faculty do
     resources :redesign_summaries, except: [:create, :new], path: '/redesign-summaries'
   end
- 
+
   get '/star-learning-communities', to: 'star_learning_communities#show'
   namespace :star_learning_communities, path: '/star-learning-communities' do
     resources :registrations
   end
+
   namespace :api do
     namespace :v1 do
       namespace :faculty do

--- a/db/migrate/20170307185301_add_timestamps_to_institutional_units.rb
+++ b/db/migrate/20170307185301_add_timestamps_to_institutional_units.rb
@@ -1,0 +1,6 @@
+class AddTimestampsToInstitutionalUnits < ActiveRecord::Migration[5.0]
+  def change
+    add_column :institutional_units, :created_at, :datetime
+    add_column :institutional_units, :updated_at, :datetime
+  end
+end

--- a/db/migrate/20170309191856_add_slug_to_institutional_units.rb
+++ b/db/migrate/20170309191856_add_slug_to_institutional_units.rb
@@ -1,0 +1,5 @@
+class AddSlugToInstitutionalUnits < ActiveRecord::Migration[5.0]
+  def change
+    add_column :institutional_units, :slug, :string, null: false
+  end
+end

--- a/db/migrate/20170315185744_add_current_chair_to_administrator_unit_associations.rb
+++ b/db/migrate/20170315185744_add_current_chair_to_administrator_unit_associations.rb
@@ -1,0 +1,5 @@
+class AddCurrentChairToAdministratorUnitAssociations < ActiveRecord::Migration[5.0]
+  def change
+    add_column :administrator_unit_associations, :current_chair, :boolean, default: false
+  end
+end

--- a/db/migrate/20170315202414_add_current_dean_to_administrator_unit_associations.rb
+++ b/db/migrate/20170315202414_add_current_dean_to_administrator_unit_associations.rb
@@ -1,0 +1,5 @@
+class AddCurrentDeanToAdministratorUnitAssociations < ActiveRecord::Migration[5.0]
+  def change
+    add_column :administrator_unit_associations, :current_dean, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170306202552) do
+ActiveRecord::Schema.define(version: 20170315202414) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,8 @@ ActiveRecord::Schema.define(version: 20170306202552) do
   create_table "administrator_unit_associations", force: :cascade do |t|
     t.integer "institutional_administrator_id"
     t.integer "institutional_unit_id"
+    t.boolean "current_chair",                  default: false
+    t.boolean "current_dean"
     t.index ["institutional_administrator_id"], name: "index_admin_unit_associations_on_administrator_id", using: :btree
     t.index ["institutional_unit_id"], name: "index_admin_unit_associations_on_unit_id", using: :btree
   end
@@ -217,11 +219,14 @@ ActiveRecord::Schema.define(version: 20170306202552) do
   end
 
   create_table "institutional_units", force: :cascade do |t|
-    t.string  "type"
-    t.string  "name"
-    t.string  "mail_stop"
-    t.integer "institutional_unit_id"
-    t.integer "campus_id"
+    t.string   "type"
+    t.string   "name"
+    t.string   "mail_stop"
+    t.integer  "institutional_unit_id"
+    t.integer  "campus_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "slug",                  null: false
     t.index ["campus_id"], name: "index_institutional_units_on_campus_id", using: :btree
     t.index ["institutional_unit_id"], name: "index_institutional_units_on_institutional_unit_id", using: :btree
   end

--- a/spec/factories/institutional_college.rb
+++ b/spec/factories/institutional_college.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  
+  factory :institutional_college do
+    name "The College of Learning"
+    slug "the-college-of-learning"
+    mail_stop "123"
+
+    campus
+  end
+end

--- a/spec/features/institutional_colleges_spec.rb
+++ b/spec/features/institutional_colleges_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+RSpec.feature "Institutional College Management" do
+  
+
+  feature "Institutional College index" do
+    let(:institutional_college) { create(:institutional_college) }
+
+    scenario "visit index page for a campus" do
+      visit "/campuses/#{institutional_college.campus.slug}/colleges"
+
+      expect(page).to have_content(institutional_college.name)
+    end
+  end
+end

--- a/spec/models/administrator_unit_association_spec.rb
+++ b/spec/models/administrator_unit_association_spec.rb
@@ -5,5 +5,7 @@ RSpec.describe AdministratorUnitAssociation do
   describe "Associations" do
     it { should belong_to(:institutional_administrator) }
     it { should belong_to(:institutional_unit) }
+    it { should belong_to(:institutional_college) }
+    it { should belong_to(:institutional_department) }
   end
 end

--- a/spec/models/institutional_admininistrator_spec.rb
+++ b/spec/models/institutional_admininistrator_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe InstitutionalAdministrator do
   end
 
   describe "associations" do
-    it { should have_many(:administrator_unit_associations) }
+    it { should have_many(:administrator_unit_associations).dependent(:destroy) }
+    it { should have_many(:colleges).through(:administrator_unit_associations).source(:institutional_college) }
+    it { should have_many(:departments).through(:administrator_unit_associations).source(:institutional_department) }
   end
 end

--- a/spec/models/institutional_college_spec.rb
+++ b/spec/models/institutional_college_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 RSpec.describe InstitutionalCollege do
 
   describe "Associations" do
-    it { should have_many(:administrator_unit_associations).with_foreign_key('institutional_unit_id') }
+    it { should have_many(:administrator_unit_associations).with_foreign_key('institutional_unit_id').dependent(:destroy) }
     it { should have_many(:deans).through(:administrator_unit_associations).source('institutional_administrator') }
-    it { should have_many(:departments).class_name('InstitutionalDepartment') }
+    it { should have_many(:departments).class_name('InstitutionalDepartment').dependent(:nullify) }
   end
 end

--- a/spec/models/institutional_department_spec.rb
+++ b/spec/models/institutional_department_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe InstitutionalDepartment do
   
   describe "associations" do
     it { should belong_to(:institutional_unit) }      
-    it { should have_many(:administrator_unit_associations).with_foreign_key("institutional_unit_id") }
+    it { should have_many(:administrator_unit_associations).with_foreign_key("institutional_unit_id").dependent(:destroy) }
     it { should have_many(:chairs).through(:administrator_unit_associations).source(:institutional_administrator) }
-    it { should have_many(:department_faculty_associations).with_foreign_key("department_id") }
+    it { should have_many(:department_faculty_associations).with_foreign_key("department_id").dependent(:destroy) }
     it { should have_many(:faculty).through(:department_faculty_associations) }
   end
 end

--- a/spec/models/institutional_faculty_spec.rb
+++ b/spec/models/institutional_faculty_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe InstitutionalFaculty do
   end
   describe "associations" do
     it { should belong_to(:campus) }
-    it { should have_many(:faculty_course_associations) }
+    it { should have_many(:faculty_course_associations).dependent(:destroy) }
     it { should have_many(:courses).through(:faculty_course_associations).source(:institutional_course) }
   end
 end


### PR DESCRIPTION
We need to keep an accurate list of department/college deans and chairs
to use when we disseminate our student nomination results. This set of
resources will add a user interface on top of that list.